### PR TITLE
Eliminando warning en la construcción del sitio

### DIFF
--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -7,11 +7,11 @@ layout: default
   <!--  <h1 class="post-title">{{ page.title }}</h1>-->
   </header>
 
-  {{%if page.tagline%}}
+  {%if page.tagline%}
   <div class="tagline">
   <span class="page-title">{{page.title}}</span> <span class="page-tagline"><em>{{page.tagline}}</em></span>
   </div>
-  {{% endif %}}
+  {% endif %}
 
   <div class="post-content">
     {{ content }}


### PR DESCRIPTION
El if no estaba bien hecho. Sobraban llaves.
Antes, al generar el sitio, se mostraban estos avisos

``` bash
    Liquid Warning: Liquid syntax error (line 7): Unexpected character % in "{{%if page.tagline%}}" in /_layouts/page.html                                                                                                                  
    Liquid Warning: Liquid syntax error (line 11): Unexpected character % in "{{% endif %}}" in /_layouts/page.html
    Liquid Warning: Liquid syntax error (line 7): Unexpected character % in "{{%if page.tagline%}}" in /_layouts/page.html                                                                                                                  
    Liquid Warning: Liquid syntax error (line 11): Unexpected character % in "{{% endif %}}" in /_layouts/page.html

```
